### PR TITLE
Config path/pattern, plugin fixes, README, scripted tests, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,37 @@
-# SBT specific
+# sbt
 target/
 project/target/
-project/project/target/
-lib_managed/
-src_managed/
-project/boot/
-.history
-.cache
-.lib/
+project/project/
+*.jar
+!lib/*.jar
 
-# Scala-IDE specific
-.scala_dependencies
-.worksheet
-
-# IntelliJ
-.idea/
-*.iml
-*.iws
-*.ipr
-out/
-
-# VS Code
-.vscode/
-.metals/
+# Bloop / BSP
 .bloop/
+.bsp/
 
-# Mac
+# IDE / editors
+.idea/
+.vscode/
+*.iml
+.metals/
+project/metals.sbt
+
+# OS
 .DS_Store
+Thumbs.db
+
+# Env / secrets
+*.env
+credentials.env
+.env
+.env.*
+
+# Logs
+*.log
+
+# Scala
+*.class
+*.log
+
+artifactory-test
+compose.yaml

--- a/README.md
+++ b/README.md
@@ -9,58 +9,7 @@ password=user_pat
 pull-repo=maven-virtual
 publish-repo=maven-local
 ```
+
+Config path defaults to the user home directory and the file pattern to `.*\.artifactrepo`. Override in your build with `artifactRepoConfigPath` and `artifactRepoConfigFilePattern`.
+
 Add the plugin to `project/plugins.sbt` for regular project dependencies, and to `project/project/plugins.sbt` for plugins used in the build.
-
-## Debug Logging
-
-To enable detailed debug logging showing what the plugin is doing, start SBT with the debug flag:
-
-```bash
-sbt -Dsbt.artifact.repo.debug=true
-```
-
-This will show:
-- Which configuration files are being searched and loaded
-- What properties are found in each file
-- Which properties are missing (if any)
-- Configuration details for successfully loaded repos
-- Summary of configured repositories and credentials
-
-Example debug output:
-```
-[sbt-artifact-repo][DEBUG] Initializing artifact repository plugin
-[sbt-artifact-repo][DEBUG] Searching for .artifactrepo files in user home: /home/user
-[sbt-artifact-repo][DEBUG] Found 1 .artifactrepo file(s)
-[sbt-artifact-repo][DEBUG] Attempting to read configuration from: /home/user/.artifactrepo/myrepo.artifactrepo
-[sbt-artifact-repo][DEBUG]   Properties found: pull-repo, host, publish-repo, realm, user, protocol, password
-[sbt-artifact-repo][DEBUG]   All required properties present
-[sbt-artifact-repo][DEBUG]   Creating configuration for host: repo.acme.com
-[sbt-artifact-repo] Loaded configuration from: /home/user/.artifactrepo/myrepo.artifactrepo
-[sbt-artifact-repo][DEBUG]   Configuration details: host=repo.acme.com, pullRepo=maven-virtual, publishRepo=maven-local, protocol=https
-```
-
-## Development
-
-### Running Tests
-
-The plugin has both unit tests and integration tests using the SBT scripted framework.
-
-**Unit tests:**
-```bash
-sbt test
-```
-
-**Scripted integration tests:**
-```bash
-sbt scripted
-```
-
-Run a specific scripted test:
-```bash
-sbt "scripted sbt-artifact-repo/valid-config"
-```
-
-The scripted tests include:
-- `valid-config`: Tests loading a valid configuration file
-- `missing-properties`: Tests handling incomplete configuration files
-- `no-config`: Tests that the plugin works when no configuration file exists

--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,9 @@ enablePlugins(SbtPlugin)
 lazy val root = (project in file("."))
     .settings(
       name := "sbt-artifact-repo",
+      libraryDependencies ++= Seq(
+        "org.scalatest" %% "scalatest" % "3.2.19" % Test
+      ),
       scriptedLaunchOpts := { scriptedLaunchOpts.value ++
         Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
       },

--- a/build.sbt
+++ b/build.sbt
@@ -19,14 +19,9 @@ enablePlugins(SbtPlugin)
 
 lazy val root = (project in file("."))
     .settings(
-        name := "sbt-artifact-repo",
-        libraryDependencies ++= Seq(
-          "org.scalatest" %% "scalatest" % "3.2.19" % Test
-        ),
-        // Scripted test settings
-        scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-          Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
-        },
-        scriptedBufferLog := false
+      name := "sbt-artifact-repo",
+      scriptedLaunchOpts := { scriptedLaunchOpts.value ++
+        Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+      },
+      scriptedBufferLog := false
     )
-    .enablePlugins(ScriptedPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.0")
-
-libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/ArtifactRepoPlugin.scala
+++ b/src/main/scala/ArtifactRepoPlugin.scala
@@ -1,17 +1,21 @@
 package com.highlylogical.oss
 
-import sbt.io.Path
-import sbt.toRepositoryName
 import sbt.{AutoPlugin, Credentials, Def, Keys, MavenRepository}
+import sbt._
+import sbt.util.Logger
 
-import java.io.{File, FileInputStream, FilenameFilter}
+import java.io.{File, FileInputStream}
 import java.util.Properties
-import scala.util.{Try, Success, Failure}
 
 case class ArtifactRepoConfig(host: String, publishRepo: String, pullRepo: String, credentials: Credentials, protocol: String = "https") {
   def mavenResolver(direction: String): MavenRepository = {
     val repo = if (direction == "pull") pullRepo else publishRepo
-    s"$repo-$direction" at s"$protocol://$host/$repo"
+    val mavenRepo = s"$repo-$direction" at s"$protocol://$host/$repo"
+    if (protocol == "http") {
+      mavenRepo.withAllowInsecureProtocol(true)
+    } else {
+      mavenRepo    
+    }
   }
 }
 
@@ -19,110 +23,87 @@ object ArtifactRepoPlugin extends AutoPlugin {
   override def trigger = allRequirements
 
   override def requires = sbt.plugins.JvmPlugin
+
+  object autoImport {
+    val artifactRepoConfigPath = settingKey[File]("Path to location of artifact repo configurations")
+    val artifactRepoConfigFilePattern = settingKey[String]("Pattern match for config files")
+  }
+
+  import autoImport._
   
-  // Enable debug logging with -Dsbt.artifact.repo.debug=true
-  private val debugEnabled: Boolean = sys.props.get("sbt.artifact.repo.debug").contains("true")
-  
-  private def debug(msg: => String): Unit = {
-    if (debugEnabled) {
-      println(s"[sbt-artifact-repo][DEBUG] $msg")
-    }
+  lazy val artifactRepoSettings: Seq[Def.Setting[_]] = Seq(
+    artifactRepoConfigFilePattern := ".*\\.artifactrepo",
+    artifactRepoConfigPath := sbt.io.Path.userHome
+  )
+
+  override def globalSettings: Seq[Setting[_]] = artifactRepoSettings
+
+  def loadConfig(path: File, pattern: String, log: Logger): Seq[ArtifactRepoConfig] = {
+    val files = Option(path.listFiles()).getOrElse(Array.empty[File])
+    files.filter(f => f.isFile && f.getName.matches(pattern)).flatMap { f =>
+      readRepoConfig(f) match {
+        case Right(config) => Some(config)
+        case Left(err) =>
+          log.warn(s"Invalid artifact repo config $f: $err")
+          None
+      }
+    }.toSeq
+  }
+
+  def loadCredentials(path: File, pattern: String, log: Logger): Seq[Credentials] = {
+    loadConfig(path, pattern, log).map(_.credentials)
+  }
+
+  def loadPublishRepo(path: File, pattern: String, log: Logger): Option[MavenRepository] = {
+    loadConfig(path, pattern, log).headOption.map(_.mavenResolver("publish"))
+  }
+
+  def loadResolvers(path: File, pattern: String, log: Logger): Seq[MavenRepository] = {
+    loadConfig(path, pattern, log).map(_.mavenResolver("pull")).toSeq
   }
 
   override def projectSettings: Seq[Def.Setting[_]] = {
-    debug("Initializing artifact repository plugin")
-    val pullRepos = artifactRepos.map(_.mavenResolver("pull"))
-    val publishRepo = artifactRepos.headOption.map(_.mavenResolver("publish"))
-    val credentials = artifactRepos.map(_.credentials)
-    
-    debug(s"Configured ${pullRepos.size} pull repositories")
-    debug(s"Configured publish repository: ${publishRepo.map(_.name).getOrElse("none")}")
-    debug(s"Configured ${credentials.size} credential(s)")
-    
     Seq(
-      Keys.credentials ++= credentials,
-      Keys.resolvers ++= pullRepos,
-      Keys.publishTo := publishRepo
+      Keys.credentials ++= loadCredentials(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value),
+      Keys.resolvers ++= loadResolvers(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value),
+      Keys.publishTo := loadPublishRepo(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value)
     )
   }
 
-
-  lazy val artifactRepos: Seq[ArtifactRepoConfig] = {
-    debug(s"Searching for .artifactrepo files in user home: ${Path.userHome}")
-    
-    val configFiles = Path.userHome.listFiles(new FilenameFilter {
-      override def accept(dir: File, name: String): Boolean = {
-        name.endsWith(".artifactrepo")
-      }
-    })
-    
-    debug(s"Found ${configFiles.length} .artifactrepo file(s)")
-    
-    val results = configFiles.map(file => (file, readRepoConfig(file)))
-    val (successfulConfigs, failedConfigs) = results.partition(_._2.isRight)
-    
-    debug(s"Successfully parsed ${successfulConfigs.length} configuration(s)")
-    debug(s"Failed to parse ${failedConfigs.length} configuration(s)")
-    
-    // Log successful configuration loads
-    successfulConfigs.foreach {
-      case (file, Right(config)) =>
-        println(s"[sbt-artifact-repo] Loaded configuration from: $file")
-        debug(s"  Configuration details: host=${config.host}, pullRepo=${config.pullRepo}, publishRepo=${config.publishRepo}, protocol=${config.protocol}")
-      case _ => // This shouldn't happen due to partition
-    }
-    
-    // Log errors
-    failedConfigs.foreach {
-      case (file, Left(errorMsg)) =>
-        System.err.println(s"[sbt-artifact-repo] $errorMsg")
-      case _ => // This shouldn't happen due to partition
-    }
-    
-    successfulConfigs.collect {
-      case (_, Right(config)) => config
-    }
-  }
-
-  import scala.collection.JavaConverters._
-  
   def readRepoConfig(file: File): Either[String, ArtifactRepoConfig] = {
-    debug(s"Attempting to read configuration from: $file")
-    
-    Try {
-      val props = new Properties()
-      props.load(new FileInputStream(file))
-      val keys = props.stringPropertyNames().asScala.toSet
-      
-      debug(s"  Properties found: ${keys.mkString(", ")}")
-      
-      val requiredKeys = Set("realm", "host", "user", "password", "pull-repo", "publish-repo")
-      val missingKeys = requiredKeys -- keys
-      
-      if (missingKeys.nonEmpty) {
-        debug(s"  Missing required properties: ${missingKeys.mkString(", ")}")
-        Left(s"Configuration file '$file' is missing required properties: ${missingKeys.mkString(", ")}")
-      } else {
-        debug(s"  All required properties present")
-        debug(s"  Creating configuration for host: ${props.getProperty("host")}")
-        Right(ArtifactRepoConfig(
-          props.getProperty("host"),
-          props.getProperty("publish-repo"),
-          props.getProperty("pull-repo"),
-          Credentials(
-            props.getProperty("realm"),
-            props.getProperty("host"),
-            props.getProperty("user"),
-            props.getProperty("password")
-          ),
-          props.getProperty("protocol", "https")
-        ))
+    val props = new Properties()
+    var stream: FileInputStream = null
+    try {
+      try {
+        stream = new FileInputStream(file)
+        props.load(stream)
+      } finally {
+        if (stream != null) try { stream.close() } catch { case _: Exception => }
       }
-    } match {
-      case Success(result) => result
-      case Failure(exception) => 
-        debug(s"  Exception reading file: ${exception.getClass.getSimpleName}: ${exception.getMessage}")
-        Left(s"Failed to read configuration file '$file': ${exception.getMessage}")
+      val keys = props.stringPropertyNames()
+      val requiredKeys = Set("realm", "host", "user", "password", "pull-repo", "publish-repo")
+      if (!requiredKeys.forall(keys.contains)) {
+        return Left("Not all properties present")
+      }
+      def get(key: String, default: String = ""): String = Option(props.getProperty(key)).getOrElse(default).trim
+      val host = get("host")
+      val publishRepo = get("publish-repo")
+      val pullRepo = get("pull-repo")
+      val realm = get("realm")
+      val user = get("user")
+      val password = get("password")
+      if (host.isEmpty || publishRepo.isEmpty || pullRepo.isEmpty || realm.isEmpty || user.isEmpty || password.isEmpty) {
+        return Left("Required property missing or empty")
+      }
+      Right(ArtifactRepoConfig(
+        host,
+        publishRepo,
+        pullRepo,
+        Credentials(realm, host, user, password),
+        props.getProperty("protocol", "https").trim match { case "" => "https"; case p => p }
+      ))
+    } catch {
+      case e: java.io.IOException => Left(Option(e.getMessage).getOrElse(e.toString))
     }
   }
 }

--- a/src/main/scala/ArtifactRepoPlugin.scala
+++ b/src/main/scala/ArtifactRepoPlugin.scala
@@ -6,6 +6,7 @@ import sbt.util.Logger
 
 import java.io.{File, FileInputStream}
 import java.util.Properties
+import scala.util.{Try, Success, Failure}
 
 case class ArtifactRepoConfig(host: String, publishRepo: String, pullRepo: String, credentials: Credentials, protocol: String = "https") {
   def mavenResolver(direction: String): MavenRepository = {
@@ -30,7 +31,9 @@ object ArtifactRepoPlugin extends AutoPlugin {
   }
 
   import autoImport._
-  
+
+  private val artifactRepoConfigs = settingKey[Seq[ArtifactRepoConfig]]("Loaded artifact repo configs (cached per project)")
+
   lazy val artifactRepoSettings: Seq[Def.Setting[_]] = Seq(
     artifactRepoConfigFilePattern := ".*\\.artifactrepo",
     artifactRepoConfigPath := sbt.io.Path.userHome
@@ -64,16 +67,17 @@ object ArtifactRepoPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = {
     Seq(
-      Keys.credentials ++= loadCredentials(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value),
-      Keys.resolvers ++= loadResolvers(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value),
-      Keys.publishTo := loadPublishRepo(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value)
+      artifactRepoConfigs := loadConfig(artifactRepoConfigPath.value, artifactRepoConfigFilePattern.value, Keys.sLog.value),
+      Keys.credentials ++= artifactRepoConfigs.value.map(_.credentials),
+      Keys.resolvers ++= artifactRepoConfigs.value.map(_.mavenResolver("pull")),
+      Keys.publishTo := artifactRepoConfigs.value.headOption.map(_.mavenResolver("publish"))
     )
   }
 
   def readRepoConfig(file: File): Either[String, ArtifactRepoConfig] = {
     val props = new Properties()
-    var stream: FileInputStream = null
-    try {
+    Try {
+      var stream: FileInputStream = null
       try {
         stream = new FileInputStream(file)
         props.load(stream)
@@ -83,27 +87,30 @@ object ArtifactRepoPlugin extends AutoPlugin {
       val keys = props.stringPropertyNames()
       val requiredKeys = Set("realm", "host", "user", "password", "pull-repo", "publish-repo")
       if (!requiredKeys.forall(keys.contains)) {
-        return Left("Not all properties present")
+        Left("Not all properties present")
+      } else {
+        def get(key: String, default: String = ""): String = Option(props.getProperty(key)).getOrElse(default).trim
+        val host = get("host")
+        val publishRepo = get("publish-repo")
+        val pullRepo = get("pull-repo")
+        val realm = get("realm")
+        val user = get("user")
+        val password = get("password")
+        if (host.isEmpty || publishRepo.isEmpty || pullRepo.isEmpty || realm.isEmpty || user.isEmpty || password.isEmpty) {
+          Left("Required property missing or empty")
+        } else {
+          Right(ArtifactRepoConfig(
+            host,
+            publishRepo,
+            pullRepo,
+            Credentials(realm, host, user, password),
+            props.getProperty("protocol", "https").trim match { case "" => "https"; case p => p }
+          ))
+        }
       }
-      def get(key: String, default: String = ""): String = Option(props.getProperty(key)).getOrElse(default).trim
-      val host = get("host")
-      val publishRepo = get("publish-repo")
-      val pullRepo = get("pull-repo")
-      val realm = get("realm")
-      val user = get("user")
-      val password = get("password")
-      if (host.isEmpty || publishRepo.isEmpty || pullRepo.isEmpty || realm.isEmpty || user.isEmpty || password.isEmpty) {
-        return Left("Required property missing or empty")
-      }
-      Right(ArtifactRepoConfig(
-        host,
-        publishRepo,
-        pullRepo,
-        Credentials(realm, host, user, password),
-        props.getProperty("protocol", "https").trim match { case "" => "https"; case p => p }
-      ))
-    } catch {
-      case e: java.io.IOException => Left(Option(e.getMessage).getOrElse(e.toString))
+    } match {
+      case Success(either) => either
+      case Failure(e) => Left(Option(e.getMessage).getOrElse(e.toString))
     }
   }
 }

--- a/src/sbt-test/sbt-artifact-repo/simple/build.sbt
+++ b/src/sbt-test/sbt-artifact-repo/simple/build.sbt
@@ -1,0 +1,43 @@
+version := "0.1.0"
+scalaVersion := "2.12.20"
+
+lazy val check = TaskKey[Unit]("check")
+check / aggregate := true
+
+import TestUtils._
+import sbt.librarymanagement.ivy.DirectCredentials
+import org.scalatest.matchers.should._
+
+
+def checkImpl(projectName: String): Def.Initialize[Task[Unit]] = Def.task {
+  
+
+  val testExpectation = expectations(projectName)
+
+  publishToShouldBe(testExpectation.publish, publishTo.value)
+  compareCredentials(testExpectation.credentials, credentials.value)
+  compareResolvers(testExpectation.resolvers, resolvers.value) shouldBe true
+}
+
+lazy val basicConfig = project
+  .settings(
+    artifactRepoConfigPath := file("./testconfigs/simpletest"),
+    check := checkImpl("basic").value
+  )
+
+lazy val httpConfig = project
+.settings(
+  artifactRepoConfigPath := file("./testconfigs/httptest"),
+  check := checkImpl("http").value
+)
+
+lazy val expectations: Map[String, Expectations] = Map(
+  "basic" -> Expectations(
+    Option(MavenRepository("artifacts/local-publish", "https://artifacts.acme.com/artifacts/local")),
+    Seq(MavenRepository("artifacts/virtual-pull", "https://artifacts.acme.com/artifacts/virtual")),
+    Seq(new DirectCredentials("Artifact Realm", "artifacts.acme.com", "repo-user", "userpw"))),
+  "http" -> Expectations(
+    Option(MavenRepository("artifacts/local-publish", "http://artifacts.acme.com/artifacts/local")),
+    Seq(MavenRepository("artifacts/virtual-pull", "http://artifacts.acme.com/artifacts/virtual")),
+    Seq(new DirectCredentials("Artifact Realm", "artifacts.acme.com", "repo-user", "userpw")))
+)

--- a/src/sbt-test/sbt-artifact-repo/simple/build.sbt
+++ b/src/sbt-test/sbt-artifact-repo/simple/build.sbt
@@ -14,8 +14,8 @@ def checkImpl(projectName: String): Def.Initialize[Task[Unit]] = Def.task {
 
   val testExpectation = expectations(projectName)
 
-  publishToShouldBe(testExpectation.publish, publishTo.value)
-  compareCredentials(testExpectation.credentials, credentials.value)
+  publishToShouldBe(testExpectation.publish, publishTo.value) shouldBe true
+  compareCredentials(testExpectation.credentials, credentials.value) shouldBe true
   compareResolvers(testExpectation.resolvers, resolvers.value) shouldBe true
 }
 

--- a/src/sbt-test/sbt-artifact-repo/simple/project/Common.scala
+++ b/src/sbt-test/sbt-artifact-repo/simple/project/Common.scala
@@ -1,0 +1,64 @@
+import sbt.Credentials
+import sbt.librarymanagement.ivy.DirectCredentials
+import sbt.Resolver
+import sbt.MavenRepository
+import org.scalatest.matchers.should._
+import org.scalatest.matchers.should.Matchers
+
+object TestUtils extends Matchers {
+
+    case class Expectations(publish: Option[MavenRepository], resolvers: Seq[MavenRepository], credentials: Seq[DirectCredentials])
+
+    import org.scalactic.Equality
+
+    implicit val directCredentialsEquality: Equality[DirectCredentials] = new Equality[DirectCredentials] {
+        override def areEqual(a: DirectCredentials, b: Any): Boolean = b match {
+            case other: DirectCredentials =>
+            a.realm == other.realm &&
+            a.host.equalsIgnoreCase(other.host) && // Case-insensitive comparison for host
+            a.userName == other.userName &&        // Exact match for username
+            a.passwd == other.passwd               // Exact match for password
+            case _ => false
+        }
+    }
+
+    def compareCredentials(expected: Seq[DirectCredentials], actual: Seq[Credentials]) = {
+        expected.forall { dc =>
+            actual.exists {
+                case adc: DirectCredentials =>
+                    adc.realm == dc.realm &&
+                    adc.host.toLowerCase() == dc.host.toLowerCase() &&
+                    adc.userName == dc.userName &&
+                    adc.passwd == dc.passwd
+                case _ => false
+            }
+        }
+    }
+
+    def publishToShouldBe(expected: Option[MavenRepository], actual: Option[Resolver]) =
+
+        expected.forall { er =>
+            actual.exists {
+                case ar: MavenRepository =>
+                    er.root == ar.root && er.name == ar.name
+                case _ => false
+            }
+        }
+
+    def compareResolvers(expected: Seq[MavenRepository], actual: Seq[Resolver]): Boolean =
+        expected.forall { er =>
+            actual.exists {
+                case ar: MavenRepository => er.root == ar.root && er.name == ar.name
+                case _ => false
+            }
+        }
+
+    // def compareCredentials(expected: DirectCredentials, actual: DirectCredentials) = {
+    //     actual should have {
+    //         'realm (expected.realm)
+    //         'host (expected.host)
+    //         'userName (expected.userName)
+    //         'passwd (expected.passwd)
+    //     }
+    // }
+}

--- a/src/sbt-test/sbt-artifact-repo/simple/project/plugins.sbt
+++ b/src/sbt-test/sbt-artifact-repo/simple/project/plugins.sbt
@@ -1,0 +1,8 @@
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Compile
+
+sys.props.get("plugin.version") match {
+  case Some(x) => addSbtPlugin("com.highlylogical.oss" % "sbt-artifact-repo" % x)
+  case _ => sys.error("""|The system property 'plugin.version' is not defined.
+                         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+}
+

--- a/src/sbt-test/sbt-artifact-repo/simple/src/main/scala/hello.scala
+++ b/src/sbt-test/sbt-artifact-repo/simple/src/main/scala/hello.scala
@@ -1,0 +1,5 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("hello")
+  }
+}

--- a/src/sbt-test/sbt-artifact-repo/simple/test
+++ b/src/sbt-test/sbt-artifact-repo/simple/test
@@ -1,0 +1,5 @@
+> reload
+> clean
+> compile
+
+> check

--- a/src/sbt-test/sbt-artifact-repo/simple/testconfigs/httptest/http.artifactrepo
+++ b/src/sbt-test/sbt-artifact-repo/simple/testconfigs/httptest/http.artifactrepo
@@ -1,0 +1,7 @@
+realm=Artifact Realm
+user=repo-user
+password=userpw
+pull-repo=artifacts/virtual
+publish-repo=artifacts/local
+host=artifacts.acme.com
+protocol=http

--- a/src/sbt-test/sbt-artifact-repo/simple/testconfigs/simpletest/simple.artifactrepo
+++ b/src/sbt-test/sbt-artifact-repo/simple/testconfigs/simpletest/simple.artifactrepo
@@ -1,0 +1,6 @@
+realm=Artifact Realm
+user=repo-user
+password=userpw
+pull-repo=artifacts/virtual
+publish-repo=artifacts/local
+host=artifacts.acme.com

--- a/src/test/scala/com/highlylogical/oss/ArtifactRepoPluginSpec.scala
+++ b/src/test/scala/com/highlylogical/oss/ArtifactRepoPluginSpec.scala
@@ -108,10 +108,7 @@ class ArtifactRepoPluginSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     
     result.isLeft should be(true)
     val error = result.left.get
-    error should include("missing required properties")
-    error should include("password")
-    error should include("pull-repo")
-    error should include("publish-repo")
+    error should include("Not all properties present")
   }
 
   it should "return error for non-existent file" in {
@@ -121,7 +118,7 @@ class ArtifactRepoPluginSpec extends AnyFlatSpec with Matchers with BeforeAndAft
     
     result.isLeft should be(true)
     val error = result.left.get
-    error should include("Failed to read configuration file")
+    error should (include("No such file") or include("nonexistent.artifactrepo"))
   }
 
   it should "return error for invalid file format" in {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how repositories/credentials are discovered and applied to builds (including allowing insecure HTTP resolvers), and adjusts parsing/error behavior which could affect existing users’ configurations.
> 
> **Overview**
> Adds *configurable discovery* for artifact repo configs via new settings `artifactRepoConfigPath` and `artifactRepoConfigFilePattern`, with configs loaded once per project and applied to `credentials`, `resolvers`, and `publishTo`.
> 
> Updates resolver creation to explicitly allow insecure protocol when `protocol=http`, refactors config loading to use SBT logging (warn on invalid files) instead of custom debug printlns, and tightens config parsing/validation (trim values, close streams, simpler error messages).
> 
> Introduces new SBT scripted integration test `sbt-test/.../simple` (including an `http` case) and cleans up build/plugin setup, along with a refreshed `.gitignore` and a shortened README reflecting the new configuration overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13f2aa134d885c40eee1fe3692c50794bfe9a102. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->